### PR TITLE
Export/Import Histograms

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -15,6 +15,7 @@ type Bracket struct {
 }
 
 // A Snapshot is an exported view of a Histogram, useful for serializing them.
+// A Histogram can be constructed from it by passing it to Import.
 type Snapshot struct {
 	LowestTrackableValue  int64
 	HighestTrackableValue int64

--- a/hdr.go
+++ b/hdr.go
@@ -34,7 +34,7 @@ type Histogram struct {
 
 // New returns a new Histogram instance capable of tracking values in the given
 // range and with the given amount of precision.
-func New(minValue, maxValue int64, sigfigs int) *Histogram {
+func New(minValue, maxValue, sigfigs int64) *Histogram {
 	if sigfigs < 1 || 5 < sigfigs {
 		panic(fmt.Errorf("sigfigs must be [1,5] (was %d)", sigfigs))
 	}
@@ -78,7 +78,7 @@ func New(minValue, maxValue int64, sigfigs int) *Histogram {
 		lowestTrackableValue:        minValue,
 		highestTrackableValue:       maxValue,
 		unitMagnitude:               int64(unitMagnitude),
-		significantFigures:          int64(sigfigs),
+		significantFigures:          sigfigs,
 		subBucketHalfCountMagnitude: subBucketHalfCountMagnitude,
 		subBucketHalfCount:          subBucketHalfCount,
 		subBucketMask:               subBucketMask,

--- a/hdr.go
+++ b/hdr.go
@@ -43,7 +43,7 @@ type Histogram struct {
 
 // New returns a new Histogram instance capable of tracking values in the given
 // range and with the given amount of precision.
-func New(minValue, maxValue, sigfigs int64) *Histogram {
+func New(minValue, maxValue int64, sigfigs int) *Histogram {
 	if sigfigs < 1 || 5 < sigfigs {
 		panic(fmt.Errorf("sigfigs must be [1,5] (was %d)", sigfigs))
 	}
@@ -87,7 +87,7 @@ func New(minValue, maxValue, sigfigs int64) *Histogram {
 		lowestTrackableValue:        minValue,
 		highestTrackableValue:       maxValue,
 		unitMagnitude:               int64(unitMagnitude),
-		significantFigures:          sigfigs,
+		significantFigures:          int64(sigfigs),
 		subBucketHalfCountMagnitude: subBucketHalfCountMagnitude,
 		subBucketHalfCount:          subBucketHalfCount,
 		subBucketMask:               subBucketMask,
@@ -306,7 +306,7 @@ func (h *Histogram) Export() *Snapshot {
 
 // Import returns a new Histogram populated from the Snapshot data.
 func Import(s *Snapshot) *Histogram {
-	h := New(s.LowestTrackableValue, s.HighestTrackableValue, s.SignificantFigures)
+	h := New(s.LowestTrackableValue, s.HighestTrackableValue, int(s.SignificantFigures))
 	h.counts = s.Counts
 	totalCount := int64(0)
 	for i := int32(0); i < h.countsLen; i++ {

--- a/hdr.go
+++ b/hdr.go
@@ -14,6 +14,14 @@ type Bracket struct {
 	Count, ValueAt int64
 }
 
+// A Snapshot is an exported view of a Histogram, useful for serializing them.
+type Snapshot struct {
+	LowestTrackableValue  int64
+	HighestTrackableValue int64
+	SignificantFigures    int64
+	Counts                []int64
+}
+
 // A Histogram is a lossy data structure used to record the distribution of
 // non-normally distributed data (like latency) with a high degree of accuracy
 // and a bounded degree of precision.
@@ -256,6 +264,58 @@ func (h *Histogram) CumulativeDistribution() []Bracket {
 	}
 
 	return result
+}
+
+// Equals returns true if the two Histograms are equivalent, false if not.
+func (h *Histogram) Equals(other *Histogram) bool {
+	switch {
+	case
+		h.lowestTrackableValue != other.lowestTrackableValue,
+		h.highestTrackableValue != other.highestTrackableValue,
+		h.unitMagnitude != other.unitMagnitude,
+		h.significantFigures != other.significantFigures,
+		h.subBucketHalfCountMagnitude != other.subBucketHalfCountMagnitude,
+		h.subBucketHalfCount != other.subBucketHalfCount,
+		h.subBucketMask != other.subBucketMask,
+		h.subBucketCount != other.subBucketCount,
+		h.bucketCount != other.bucketCount,
+		h.countsLen != other.countsLen,
+		h.totalCount != other.totalCount:
+		return false
+	default:
+		for i, c := range h.counts {
+			if c != other.counts[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Export returns a snapshot view of the Histogram. This can be later passed to
+// Import to construct a new Histogram with the same state.
+func (h *Histogram) Export() *Snapshot {
+	return &Snapshot{
+		LowestTrackableValue:  h.lowestTrackableValue,
+		HighestTrackableValue: h.highestTrackableValue,
+		SignificantFigures:    h.significantFigures,
+		Counts:                h.counts,
+	}
+}
+
+// Import returns a new Histogram populated from the Snapshot data.
+func Import(s *Snapshot) *Histogram {
+	h := New(s.LowestTrackableValue, s.HighestTrackableValue, s.SignificantFigures)
+	h.counts = s.Counts
+	totalCount := int64(0)
+	for i := int32(0); i < h.countsLen; i++ {
+		countAtIndex := h.counts[i]
+		if countAtIndex > 0 {
+			totalCount += countAtIndex
+		}
+	}
+	h.totalCount = totalCount
+	return h
 }
 
 func (h *Histogram) iterator() *iterator {

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -264,7 +264,7 @@ func TestSubBucketMaskOverflow(t *testing.T) {
 func TestExportImport(t *testing.T) {
 	min := int64(1)
 	max := int64(10000000)
-	sigfigs := int64(3)
+	sigfigs := 3
 	h := hdrhistogram.New(min, max, sigfigs)
 	for i := 0; i < 1000000; i++ {
 		if err := h.RecordValue(int64(i)); err != nil {
@@ -282,7 +282,7 @@ func TestExportImport(t *testing.T) {
 		t.Errorf("HighestTrackableValue was %v, but expected %v", v, max)
 	}
 
-	if v := s.SignificantFigures; v != sigfigs {
+	if v := int(s.SignificantFigures); v != sigfigs {
 		t.Errorf("SignificantFigures was %v, but expected %v", v, sigfigs)
 	}
 

--- a/window.go
+++ b/window.go
@@ -11,7 +11,7 @@ type WindowedHistogram struct {
 
 // NewWindowed creates a new WindowedHistogram with N underlying histograms with
 // the given parameters.
-func NewWindowed(n int, minValue, maxValue int64, sigfigs int) *WindowedHistogram {
+func NewWindowed(n int, minValue, maxValue, sigfigs int64) *WindowedHistogram {
 	w := WindowedHistogram{
 		idx: -1,
 		h:   make([]Histogram, n),

--- a/window.go
+++ b/window.go
@@ -11,7 +11,7 @@ type WindowedHistogram struct {
 
 // NewWindowed creates a new WindowedHistogram with N underlying histograms with
 // the given parameters.
-func NewWindowed(n int, minValue, maxValue, sigfigs int64) *WindowedHistogram {
+func NewWindowed(n int, minValue, maxValue int64, sigfigs int) *WindowedHistogram {
 	w := WindowedHistogram{
 		idx: -1,
 		h:   make([]Histogram, n),


### PR DESCRIPTION
Thanks for the golang port, super useful.

This is a stab at addressing what was discussed in issue #1. I think the consensus from that discussion was to keep the API simple. Any kind of `Histogram` serialization should be deferred to users of the library, but a way to export a view of the `Histogram` should be provided.

This introduces a `Snapshot` which is produced on `Export`. This allows users to do what they want with it and later reconstruct a `Histogram` from it using `Import`. Another item is the `Equals` method which is used to compare a `Histogram` for equality.

Also changed `New` so that the sigfigs argument is an `int64`, which reflects the type on the underlying `Histogram`.