### PR TITLE
Fix rounding to be consistent with upstream

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -478,7 +478,7 @@ func (p *pIterator) next() bool {
 		currentPercentile := (100.0 * float64(p.countToIdx)) / float64(p.h.totalCount)
 		if p.countAtIdx != 0 && p.percentileToIteratorTo <= currentPercentile {
 			p.percentile = p.percentileToIteratorTo
-			halfDistance := math.Pow(2, (math.Log(100.0/(100.0-(p.percentileToIteratorTo)))/math.Log(2))+1)
+			halfDistance := math.Trunc(math.Pow(2, math.Trunc(math.Log2(100.0/(100.0-p.percentileToIteratorTo)))+1))
 			percentileReportingTicks := float64(p.ticksPerHalfDistance) * halfDistance
 			p.percentileToIteratorTo += 100.0 / percentileReportingTicks
 			return true


### PR DESCRIPTION
The upstream (Java) implementation casts to long in a few places, which
truncates floating point numbers. This logic was missing from this port.

I think this is the code this is taken from: https://github.com/HdrHistogram/HdrHistogram/blob/aa16b7145c5f519bd2550048ba270c86c300b7f8/src/main/java/org/HdrHistogram/PercentileIterator.java#L65-L68

I don't know what, if anything, this affects (the tests pass either way, and I'm not familiar enough with the code to try to write a failing test case of my own).