### PR TITLE
prevent Mean and StdDev from being NaN

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -152,6 +152,9 @@ func (h *Histogram) Min() int64 {
 
 // Mean returns the approximate arithmetic mean of the recorded values.
 func (h *Histogram) Mean() float64 {
+	if h.totalCount == 0 {
+		return 0
+	}
 	var total int64
 	i := h.iterator()
 	for i.next() {
@@ -164,6 +167,10 @@ func (h *Histogram) Mean() float64 {
 
 // StdDev returns the approximate standard deviation of the recorded values.
 func (h *Histogram) StdDev() float64 {
+	if h.totalCount == 0 {
+		return 0
+	}
+
 	mean := h.Mean()
 	geometricDevTotal := 0.0
 

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -1,6 +1,7 @@
 package hdrhistogram_test
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -223,6 +224,16 @@ func TestCumulativeDistribution(t *testing.T) {
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("CF was %#v, but expected %#v", actual, expected)
+	}
+}
+
+func TestNaN(t *testing.T) {
+	h := hdrhistogram.New(1, 100000, 3)
+	if math.IsNaN(h.Mean()) {
+		t.Error("mean is NaN")
+	}
+	if math.IsNaN(h.StdDev()) {
+		t.Error("stddev is NaN")
 	}
 }
 


### PR DESCRIPTION
This is simply because JSON can't represent NaN.