### PR TITLE
Expose various constants used to create the histogram

### DIFF
--- a/hdr.go
+++ b/hdr.go
@@ -275,6 +275,24 @@ func (h *Histogram) CumulativeDistribution() []Bracket {
 	return result
 }
 
+// SignificantFigures returns the significant figures used to create the
+// histogram
+func (h *Histogram) SignificantFigures() int64 {
+	return h.significantFigures
+}
+
+// LowestTrackableValue returns the lower bound on values that will be added
+// to the histogram
+func (h *Histogram) LowestTrackableValue() int64 {
+	return h.lowestTrackableValue
+}
+
+// HighestTrackableValue returns the upper bound on values that will be added
+// to the histogram
+func (h *Histogram) HighestTrackableValue() int64 {
+	return h.highestTrackableValue
+}
+
 // Histogram bar for plotting
 type Bar struct {
 	From, To, Count int64

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -257,6 +257,30 @@ func TestNaN(t *testing.T) {
 	}
 }
 
+func TestSignificantFigures(t *testing.T) {
+	const sigFigs = 4
+	h := hdrhistogram.New(1, 10, sigFigs)
+	if h.SignificantFigures() != sigFigs {
+		t.Errorf("Significant figures was %v, expected %d", h.SignificantFigures(), sigFigs)
+	}
+}
+
+func TestLowestTrackableValue(t *testing.T) {
+	const minVal = 2
+	h := hdrhistogram.New(minVal, 10, 3)
+	if h.LowestTrackableValue() != minVal {
+		t.Errorf("LowestTrackableValue figures was %v, expected %d", h.LowestTrackableValue(), minVal)
+	}
+}
+
+func TestHighestTrackableValue(t *testing.T) {
+	const maxVal = 11
+	h := hdrhistogram.New(1, maxVal, 3)
+	if h.HighestTrackableValue() != maxVal {
+		t.Errorf("HighestTrackableValue figures was %v, expected %d", h.HighestTrackableValue(), maxVal)
+	}
+}
+
 func BenchmarkHistogramRecordValue(b *testing.B) {
 	h := hdrhistogram.New(1, 10000000, 3)
 	for i := 0; i < 1000000; i++ {


### PR DESCRIPTION
When embedding Histogram, it is useful to expose the constants used to create the histogram so that a histogram manager does not have to store duplicate copies of these values.